### PR TITLE
[BUG] Fix pad-conv fusion bug when pad has multiple consumers

### DIFF
--- a/onnxslim/core/optimizer.py
+++ b/onnxslim/core/optimizer.py
@@ -190,7 +190,9 @@ def find_conv_nodes(node, opset):
 
                 node.inputs.clear()
                 node.outputs.clear()
-                if len(pad_node_users) == 1:  # remove pad node if it has only one user
+                # remove pad node if it has only one user
+                if len(pad_node_users) == 1:
+                    input_variable.outputs.remove(pad_node)
                     pad_node.inputs.clear()
                     pad_node.outputs.clear()
 

--- a/onnxslim/core/optimizer.py
+++ b/onnxslim/core/optimizer.py
@@ -175,9 +175,9 @@ def find_conv_nodes(node, opset):
         if node.i(0).op == "Pad":
             pad_node = node.i(0)
             if isinstance(pad_node.inputs[1], Constant):
+                pad_node_users = get_node_users(pad_node)
                 pad_value = pad_node.inputs[1].values.tolist()
                 input_variable = node.i(0).inputs[0]
-                input_variable.outputs.remove(pad_node)
 
                 pad_variable = node.i(0).outputs[0]  # pad output variable
                 index = node.inputs.index(pad_variable)
@@ -190,8 +190,10 @@ def find_conv_nodes(node, opset):
 
                 node.inputs.clear()
                 node.outputs.clear()
-                pad_node.inputs.clear()
-                pad_node.outputs.clear()
+                if len(pad_node_users) == 1:  # remove pad node if it has only one user
+                    pad_node.inputs.clear()
+                    pad_node.outputs.clear()
+
                 conv_pads = attrs["pads"]
                 len_conv_pads = int(len(conv_pads) / 2)
 


### PR DESCRIPTION
When a Pad op has multiple consumers, the fusion process will remove the Pad op without notifying the other consumers, which cause the other consumers to have inexistent input.
To avoid this issue, need to check the consumers of the Pad op before removing it.

NOTE: PYPI version is 0.1.32 which is slightly different from the master branch, while this fix also works.

This problem can be reproduced with the following code:
```python
import onnx
import onnxslim

# Create nodes
pad_node = onnx.helper.make_node(
    'Pad',
    inputs=['input', 'pads'],
    outputs=['pad_output'],
    mode='constant',
)

conv_node_1 = onnx.helper.make_node(
    'Conv',
    name='conv1',
    inputs=['pad_output', 'weight1', 'bias1'],
    outputs=['conv_output_1'],
    kernel_shape=[3, 3],
    strides=[1, 1],
    pads=[0, 0, 0, 0],
    dilations=[1, 1],
    group=1,
)

conv_node_2 = onnx.helper.make_node(
    'Conv',
    name='conv2',
    inputs=['pad_output', 'weight2', 'bias2'],
    outputs=['conv_output_2'],
    kernel_shape=[5, 5],
    strides=[1, 1],
    pads=[0, 0, 0, 0],
    dilations=[1, 1],
    group=1,
)

# Create initializers
pads = onnx.helper.make_tensor(
    name='pads',
    data_type=onnx.TensorProto.INT64,
    dims=[8],
    vals=[2, 0, 2, 0, 2, 0, 2, 0],
)

weight1 = onnx.helper.make_tensor(
    name='weight1',
    data_type=onnx.TensorProto.FLOAT,
    dims=[3, 3, 3, 3],
    vals=[1.0] * 81,
)

bias1 = onnx.helper.make_tensor(
    name='bias1',
    data_type=onnx.TensorProto.FLOAT,
    dims=[3],
    vals=[1.0] * 3,
)

weight2 = onnx.helper.make_tensor(
    name='weight2',
    data_type=onnx.TensorProto.FLOAT,
    dims=[3, 3, 5, 5],
    vals=[2.0] * 225,
)

bias2 = onnx.helper.make_tensor(
    name='bias2',
    data_type=onnx.TensorProto.FLOAT,
    dims=[3],
    vals=[2.0] * 3,
)


# Create model
graph = onnx.helper.make_graph(
    nodes=[pad_node, conv_node_1, conv_node_2],
    name='test-model',
    inputs=[onnx.helper.make_tensor_value_info('input', onnx.TensorProto.FLOAT, [1, 3, 32, 32])],
    outputs=[
        onnx.helper.make_tensor_value_info('conv_output_1', onnx.TensorProto.FLOAT, [1, 3, '?', '?']),
        onnx.helper.make_tensor_value_info('conv_output_2', onnx.TensorProto.FLOAT, [1, 3, '?', '?']),
    ],
    initializer=[pads, weight1, bias1, weight2, bias2],
)
model = onnx.helper.make_model(graph)

# Check the model
onnx.checker.check_model(model)

# Save the model
test_onnx_file = 'test-model.onnx'
test_onnx_slimed_file = 'test-model-slim.onnx'
onnx.save(model, test_onnx_file)

# Slim & Check the model
onnxslim.slim(test_onnx_file, test_onnx_slimed_file)
onnx.checker.check_model(test_onnx_slimed_file)
```
Original model:
<img width="336" alt="image" src="https://github.com/user-attachments/assets/c7f07042-4969-45a7-b8c0-b9dba636dd07">

Slimmed model
<img width="322" alt="image" src="https://github.com/user-attachments/assets/d97547e1-94a8-462e-955d-69e954093289">

Correctly slimmed model
<img width="260" alt="image" src="https://github.com/user-attachments/assets/f2bcba40-1174-4334-ad66-9d15e48e678d">



